### PR TITLE
chore: add CI and just recipes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule: { interval: weekly }
+    groups:
+      all-actions-version-updates:
+        applies-to: version-updates
+        patterns: [ '*' ]
+      all-actions-security-updates:
+        applies-to: security-updates
+        patterns: [ '*' ]
+
+  # Update Rust dependencies
+  - package-ecosystem: cargo
+    directory: '/'
+    schedule: { interval: daily, time: '02:00' }
+    open-pull-requests-limit: 10
+    groups:
+      all-cargo-version-updates:
+        applies-to: version-updates
+        patterns: [ '*' ]
+      all-cargo-security-updates:
+        applies-to: security-updates
+        patterns: [ '*' ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,105 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+        uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with: { tool: 'just,cargo-binstall' }
+      - run: just ci-test
+
+  test-msrv:
+    name: Test MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+        uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with: { tool: 'just' }
+      - name: Read MSRV
+        id: msrv
+        run: echo "value=$(just get-msrv)" >> $GITHUB_OUTPUT
+      - name: Install MSRV Rust ${{ steps.msrv.outputs.value }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.msrv.outputs.value }}
+      - run: just ci_mode=0 ci-test-msrv  # Ignore warnings in MSRV
+
+  coverage:
+    name: Code Coverage
+    if: github.event_name != 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with: { tool: 'just,cargo-llvm-cov' }
+      - name: Generate code coverage
+        run: just ci-coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/llvm-cov/codecov.info
+
+  # This job checks if any of the previous jobs failed or were canceled.
+  # This approach also allows some jobs to be skipped if they are not needed.
+  ci-passed:
+    needs: [ test, test-msrv ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Result of the needed steps
+        run: echo "${{ toJSON(needs) }}"
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
+
+  # Release unpublished packages or create a PR with changes
+  release-plz:
+    needs: [ ci-passed ]
+    if: |
+      always()
+      && needs.ci-passed.result == 'success'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && github.repository_owner == 'oxibus'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v5
+        with: { fetch-depth: 0 }
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish to crates.io if crate's version is newer
+        uses: release-plz/action@v0.5
+        id: release
+        with: { command: release }
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - if: ${{ steps.release.outputs.releases_created == 'false' }}
+        name: If version is the same, create a PR proposing new version and changelog for the next release
+        uses: release-plz/action@v0.5
+        with: { command: release-pr }
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+on: pull_request
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+      - name: Approve Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,44 @@ description = "Derive macro for CAN DBC code generation"
 repository = "https://github.com/oxibus/dbc-data"
 keywords = ["can", "automotive", "ecu", "no-std"]
 license = "MIT OR Apache-2.0"
-
+rust-version = "1.79"
 
 [lib]
 proc-macro = true
-
-[dev-dependencies]
-assert_hex = "0.4.1"
-assert-eq-float = "0.1.4"
 
 [dependencies]
 can-dbc = "6.0.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
+
+[dev-dependencies]
+assert-eq-float = "0.1.4"
+assert_hex = "0.4.1"
+
+[lints.clippy]
+cast_possible_truncation = "allow"  # 36
+explicit_iter_loop = "allow"  # 15
+unreadable_literal = "allow"  # 13
+float_cmp = "allow"  #  9
+collapsible_else_if = "allow"  #  9
+cast_sign_loss = "allow"  #  9
+too_many_lines = "allow"  #  6
+if_not_else = "allow"  #  6
+approx_constant = "allow"  #  4
+unnecessary_semicolon = "allow"  #  3
+uninlined_format_args = "allow"  #  3
+single_match = "allow"  #  3
+single_char_pattern = "allow"  #  3
+similar_names = "allow"  #  3
+match_wild_err_arm = "allow"  #  3
+many_single_char_names = "allow"  #  3
+iter_nth_zero = "allow"  #  3
+items_after_statements = "allow"  #  3
+format_push_string = "allow"  #  3
+doc_markdown = "allow"  #  3
+default_trait_access = "allow"  #  3
+cast_lossless = "allow"  #  3
+cast_possible_wrap = "allow"  #  2
+bool_assert_comparison = "allow"  #  2
+assertions_on_constants = "allow"  #  2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# dbc-data ![License: MIT](https://img.shields.io/badge/license-MIT-blue) [![dbc-data on crates.io](https://img.shields.io/crates/v/dbc-data)](https://crates.io/crates/dbc-data) [![dbc-data on docs.rs](https://docs.rs/dbc-data/badge.svg)](https://docs.rs/dbc-data) [![Source Code Repository](https://img.shields.io/badge/Code-On%20GitLab-blue?logo=GitLab)](https://gitlab.com/mfairman/dbc-data)
+# dbc-data
+
+[![GitHub repo](https://img.shields.io/badge/github-oxibus/dbc--data-8da0cb?logo=github)](https://github.com/oxibus/dbc-data)
+[![crates.io version](https://img.shields.io/crates/v/dbc-data)](https://crates.io/crates/dbc-data)
+[![crate usage](https://img.shields.io/crates/d/dbc-data)](https://crates.io/crates/dbc-data)
+[![docs.rs status](https://img.shields.io/docsrs/dbc-data)](https://docs.rs/dbc-data)
+[![crates.io license](https://img.shields.io/crates/l/dbc-data)](https://github.com/oxibus/dbc-data)
+[![CI build status](https://github.com/oxibus/dbc-data/actions/workflows/ci.yml/badge.svg)](https://github.com/oxibus/dbc-data/actions)
+[![Codecov](https://img.shields.io/codecov/c/github/oxibus/dbc-data)](https://app.codecov.io/gh/oxibus/dbc-data)
 
 A derive-macro which produces code to access signals within CAN
 messages, as described by a `.dbc` file.  The generated code has
@@ -7,7 +15,7 @@ is `#[no_std]` compatible.
 
 ## Changelog
 
-[CHANGELOG.md][__link0]
+[CHANGELOG.md](./CHANGELOG.md)
 
 ## Example
 
@@ -88,7 +96,7 @@ code, it can be helpful to wrap them in newtype declarations.
 Additionally, it is often desirable to scope these identifiers away
 from application code by using a private module:
 
-```rust
+```rust,no_run
 mod private {
     use dbc_data::DbcData;
     #[derive(DbcData)]
@@ -96,7 +104,6 @@ mod private {
 }
 
 pub type SomeMessageName = private::some_Message_NAME;
-
 ```
 
 The application uses this wrapped type without exposure to the
@@ -122,10 +129,24 @@ interfaces.
 * Support multiplexed signals
 * Emit `enum`s for value-tables, with optional type association
 
+## Development
+
+* This project is easier to develop with [just](https://github.com/casey/just#readme), a modern alternative to `make`.
+  Install it with `cargo install just`.
+* To get a list of available commands, run `just`.
+* To run tests, use `just test`.
+
 ## License
 
-[LICENSE-MIT][__link1]
+Licensed under either of
 
+* Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <https://www.apache.org/licenses/LICENSE-2.0>)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or <https://opensource.org/licenses/MIT>)
+  at your option.
 
- [__link0]: CHANGELOG.md
- [__link1]: LICENSE-MIT
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the
+Apache-2.0 license, shall be dual-licensed as above, without any
+additional terms or conditions.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,165 @@
+#!/usr/bin/env just --justfile
+
+main_crate := file_name(justfile_directory())
+packages := '--workspace'  # All crates in the workspace
+features := '--all-features'  # Enable all features
+targets := '--all-targets'  # For all targets (lib, bin, tests, examples, benches)
+
+# if running in CI, treat warnings as errors by setting RUSTFLAGS and RUSTDOCFLAGS to '-D warnings' unless they are already set
+# Use `CI=true just ci-test` to run the same tests as in GitHub CI.
+# Use `just env-info` to see the current values of RUSTFLAGS and RUSTDOCFLAGS
+ci_mode := if env('CI', '') != '' {'1'} else {''}
+# cargo-binstall needs a workaround due to caching
+# ci_mode might be manually set by user, so re-check the env var
+binstall_args := if env('CI', '') != '' {'--no-confirm --no-track --disable-telemetry'} else {''}
+export RUSTFLAGS := env('RUSTFLAGS', if ci_mode == '1' {'-D warnings'} else {''})
+export RUSTDOCFLAGS := env('RUSTDOCFLAGS', if ci_mode == '1' {'-D warnings'} else {''})
+export RUST_BACKTRACE := env('RUST_BACKTRACE', if ci_mode == '1' {'1'} else {''})
+
+@_default:
+    {{just_executable()}} --list
+
+# Run integration tests and save its output as the new expected output
+bless *args:  (cargo-install 'cargo-insta')
+    cargo insta test --accept --unreferenced=delete {{features}} {{args}}
+
+# Build the project
+build:
+    cargo build {{packages}} {{features}} {{targets}}
+
+# Quick compile without building a binary
+check:
+    cargo check {{packages}} {{features}} {{targets}}
+
+# Generate code coverage report to upload to codecov.io
+ci-coverage: env-info && \
+            (coverage '--codecov --output-path target/llvm-cov/codecov.info')
+    # ATTENTION: the full file path above is used in the CI workflow
+    mkdir -p target/llvm-cov
+
+# Run all tests as expected by CI
+ci-test: env-info test-fmt clippy test test-doc && assert-git-is-clean
+
+# Run minimal subset of tests to ensure compatibility with MSRV
+ci-test-msrv: env-info test
+
+# Clean all build artifacts
+clean:
+    cargo clean
+    rm -f Cargo.lock
+
+# Run cargo clippy to lint the code
+clippy *args:
+    cargo clippy {{packages}} {{features}} {{targets}} {{args}}
+
+# Generate code coverage report. Will install `cargo llvm-cov` if missing.
+coverage *args='--no-clean --open':  (cargo-install 'cargo-llvm-cov')
+    cargo llvm-cov {{packages}} {{features}} {{targets}} --include-build-script {{args}}
+
+# Build and open code documentation
+docs *args='--open':
+    DOCS_RS=1 cargo doc --no-deps {{args}} {{packages}} {{features}}
+
+# Print environment info
+env-info:
+    @echo "Running for '{{main_crate}}' crate {{if ci_mode == '1' {'in CI mode'} else {'in dev mode'} }} on {{os()}} / {{arch()}}"
+    @echo "PWD $(pwd)"
+    {{just_executable()}} --version
+    rustc --version
+    cargo --version
+    rustup --version
+    @echo "RUSTFLAGS='$RUSTFLAGS'"
+    @echo "RUSTDOCFLAGS='$RUSTDOCFLAGS'"
+    @echo "RUST_BACKTRACE='$RUST_BACKTRACE'"
+
+# Reformat all code `cargo fmt`. If nightly is available, use it for better results
+fmt:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if (rustup toolchain list | grep nightly && rustup component list --toolchain nightly | grep rustfmt) &> /dev/null; then
+        echo 'Reformatting Rust code using nightly Rust fmt to sort imports'
+        cargo +nightly fmt --all -- --config imports_granularity=Module,group_imports=StdExternalCrate
+    else
+        echo 'Reformatting Rust with the stable cargo fmt.  Install nightly with `rustup install nightly` for better results'
+        cargo fmt --all
+    fi
+
+# Reformat all Cargo.toml files using cargo-sort
+fmt-toml *args:  (cargo-install 'cargo-sort')
+    cargo sort {{packages}} --grouped {{args}}
+
+# Get any package's field from the metadata
+get-crate-field field package=main_crate:  (assert-cmd 'jq')
+    cargo metadata --format-version 1 | jq -e -r '.packages | map(select(.name == "{{package}}")) | first | .{{field}} // error("Field \"{{field}}\" is missing in Cargo.toml for package {{package}}")'
+
+# Get the minimum supported Rust version (MSRV) for the crate
+get-msrv package=main_crate:  (get-crate-field 'rust_version' package)
+
+# Find the minimum supported Rust version (MSRV) using cargo-msrv extension, and update Cargo.toml
+msrv:  (cargo-install 'cargo-msrv')
+    cargo msrv find --write-msrv --ignore-lockfile {{features}}
+
+# Run cargo-release
+release *args='':  (cargo-install 'release-plz')
+    release-plz {{args}}
+
+# Check semver compatibility with prior published version. Install it with `cargo install cargo-semver-checks`
+semver *args:  (cargo-install 'cargo-semver-checks')
+    cargo semver-checks {{features}} {{args}}
+
+# Run all unit and integration tests
+test:
+    cargo test {{packages}} {{features}} {{targets}}
+
+# Test documentation generation
+test-doc:  (docs '')
+
+# Test code formatting
+test-fmt: && (fmt-toml '--check' '--check-format')
+    cargo fmt --all -- --check
+
+# Find unused dependencies. Install it with `cargo install cargo-udeps`
+udeps:  (cargo-install 'cargo-udeps')
+    cargo +nightly udeps {{packages}} {{features}} {{targets}}
+
+# Update all dependencies, including breaking changes. Requires nightly toolchain (install with `rustup install nightly`)
+update:
+    cargo +nightly -Z unstable-options update --breaking
+    cargo update
+
+# Ensure that a certain command is available
+[private]
+assert-cmd command:
+    @if ! type {{command}} > /dev/null; then \
+        echo "Command '{{command}}' could not be found. Please make sure it has been installed on your computer." ;\
+        exit 1 ;\
+    fi
+
+# Make sure the git repo has no uncommitted changes
+[private]
+assert-git-is-clean:
+    @if [ -n "$(git status --untracked-files --porcelain)" ]; then \
+      >&2 echo "ERROR: git repo is no longer clean. Make sure compilation and tests artifacts are in the .gitignore, and no repo files are modified." ;\
+      >&2 echo "######### git status ##########" ;\
+      git status ;\
+      git --no-pager diff ;\
+      exit 1 ;\
+    fi
+
+# Check if a certain Cargo command is installed, and install it if needed
+[private]
+cargo-install $COMMAND $INSTALL_CMD='' *args='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v $COMMAND > /dev/null; then
+        echo "$COMMAND could not be found. Installing..."
+        if ! command -v cargo-binstall > /dev/null; then
+            set -x
+            cargo install ${INSTALL_CMD:-$COMMAND} --locked {{args}}
+            { set +x; } 2>/dev/null
+        else
+            set -x
+            cargo binstall ${INSTALL_CMD:-$COMMAND} {{binstall_args}} --locked {{args}}
+            { set +x; } 2>/dev/null
+        fi
+    fi

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,4 @@
+[workspace]
+dependencies_update = true
+git_release_name = "v{{ version }}"
+git_tag_name = "v{{ version }}"

--- a/tomlfmt.toml
+++ b/tomlfmt.toml
@@ -1,0 +1,13 @@
+table_order = [
+    'package',
+    'lib',
+    'bin',
+    'example',
+    'bench',
+    'features',
+    'dependencies',
+    'build-dependencies',
+    'dev-dependencies',
+    'profile',
+    'lints',
+]


### PR DESCRIPTION
* automate CI and release process
* add testing for latest and MSRV versions
* automate dependabot
* add justfile with many common recipies - this way all CI and local development can be done with the same commands
* automate coverage reporting
* format Cargo.toml, sorting elements - uses cargo-sort
* add MSRV computed with `just msrv`
* in Cargo.toml, allowed all currently failing lints - another PR will clean these up