### PR TITLE
chore: release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 ## [0.1.10](https://github.com/oxibus/dbc-data/compare/v0.1.9...v0.1.10) - 2025-11-24
 
 ### Fixed
-
 - encode uses shared ref, update default trait derives ([#11](https://github.com/oxibus/dbc-data/pull/11))
+
+## [0.1.9](https://github.com/oxibus/dbc-data/compare/v0.1.8...v0.1.9) - 2025-11-23
+* Update to can-dbc v8
+* Adds the ability to specify one or more trait derivations to the generated code.  This is useful for `Debug`, `defmt::Format`, etc.
+* Minor refactors and cleanups
 
 ## 0.1.8
 * Move repo to OxiBUS GitHub organization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [0.1.10](https://github.com/oxibus/dbc-data/compare/v0.1.9...v0.1.10) - 2025-11-24
+
+### Fixed
+
+- encode uses shared ref, update default trait derives ([#11](https://github.com/oxibus/dbc-data/pull/11))
+
 ## 0.1.8
 * Move repo to OxiBUS GitHub organization
 * License change to MIT or Apache 2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbc-data"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 authors = ["Michael Fairman <mfairman@tegimeki.com>"]
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `dbc-data`: 0.1.9 -> 0.1.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.10](https://github.com/oxibus/dbc-data/compare/v0.1.9...v0.1.10) - 2025-11-24

### Fixed

- encode uses shared ref, update default trait derives ([#11](https://github.com/oxibus/dbc-data/pull/11))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).